### PR TITLE
feat: configurable ldflags

### DIFF
--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -74,7 +74,13 @@ def _create_make_script(configureParameters):
         deps = ctx.attr.deps,
         inputs = inputs,
         env_vars = user_env,
-        make_commands = make_commands,
+        make_prefix = prefix,
+        make_path = attrs.make_path,
+        make_targets = ctx.attr.targets,
+        make_args = args,
+        make_install_prefix = ctx.attr.install_prefix,
+        executable_ldflags_vars = ctx.attr.executable_ldflags_vars,
+        shared_ldflags_vars = ctx.attr.shared_ldflags_vars,
     )
 
 def _attrs():
@@ -83,6 +89,15 @@ def _attrs():
         "args": attr.string_list(
             doc = "A list of arguments to pass to the call to `make`",
         ),
+        "executable_ldflags_vars": attr.string_list(
+            doc = (
+                "A string list of variable names use as LDFLAGS for executables. These variables " +
+                "will be passed to the make command as make vars and overwrite what is defined in " +
+                "the Makefile."
+            ),
+            mandatory = False,
+            default = [],
+        ),
         "install_prefix": attr.string(
             doc = (
                 "Install prefix, i.e. relative path to where to install the result of the build. " +
@@ -90,6 +105,15 @@ def _attrs():
             ),
             mandatory = False,
             default = "$$INSTALLDIR$$",
+        ),
+        "shared_ldflags_vars": attr.string_list(
+            doc = (
+                "A string list of variable names use as LDFLAGS for shared libraries. These variables " +
+                "will be passed to the make command as make vars and overwrite what is defined in " +
+                "the Makefile."
+            ),
+            mandatory = False,
+            default = [],
         ),
         "targets": attr.string_list(
             doc = (

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -1,5 +1,5 @@
 # buildifier: disable=module-docstring
-load(":make_env_vars.bzl", "get_make_env_vars")
+load(":make_env_vars.bzl", "get_ldflags_make_vars", "get_make_env_vars")
 load(":make_script.bzl", "pkgconfig_script")
 
 # buildifier: disable=function-docstring
@@ -23,8 +23,12 @@ def create_configure_script(
         autogen,
         autogen_command,
         autogen_options,
+        make_prefix,
         make_path,
-        make_commands):
+        make_targets,
+        make_args,
+        executable_ldflags_vars,
+        shared_ldflags_vars):
     ext_build_dirs = inputs.ext_build_dirs
 
     script = pkgconfig_script(ext_build_dirs)
@@ -76,6 +80,18 @@ def create_configure_script(
         prefix_flag = prefix_flag,
         user_options = " ".join(user_options),
     ))
+
+    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs)
+
+    make_commands = []
+    for target in make_targets:
+        make_commands.append("{prefix}{make} {make_vars} {target} {args}".format(
+            prefix = make_prefix,
+            make = make_path,
+            make_vars = ldflags_make_vars,
+            args = make_args,
+            target = target,
+        ))
 
     script.extend(make_commands)
     script.append("##disable_tracing##")

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -1,6 +1,6 @@
 """A module for creating the build script for `make` builds"""
 
-load(":make_env_vars.bzl", "get_make_env_vars")
+load(":make_env_vars.bzl", "get_ldflags_make_vars", "get_make_env_vars")
 
 # buildifier: disable=function-docstring
 def create_make_script(
@@ -11,7 +11,13 @@ def create_make_script(
         env_vars,
         deps,
         inputs,
-        make_commands):
+        make_prefix,
+        make_path,
+        make_targets,
+        make_args,
+        make_install_prefix,
+        executable_ldflags_vars,
+        shared_ldflags_vars):
     ext_build_dirs = inputs.ext_build_dirs
 
     script = pkgconfig_script(ext_build_dirs)
@@ -19,7 +25,22 @@ def create_make_script(
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$ False".format(root))
 
     script.append("##enable_tracing##")
+
+    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs)
+
+    make_commands = []
+    for target in make_targets:
+        make_commands.append("{prefix}{make} {make_vars} {target} {args} PREFIX={install_prefix}".format(
+            prefix = make_prefix,
+            make = make_path,
+            make_vars = ldflags_make_vars,
+            args = make_args,
+            target = target,
+            install_prefix = make_install_prefix,
+        ))
+
     configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, make_commands)
+
     script.extend(["{env_vars} {command}".format(
         env_vars = configure_vars,
         command = command,


### PR DESCRIPTION
`configure_make()` and `make()` both resolves `LDFLAGS` to `CxxToolsInfo.cxx_linker_executable`. This hard codes the linker executable flags and does not provide a way to use the `cxx_linker_shared` flags. While this works for most use cases,  it does not work for all. An example is when we enable `--force-pic` which appends `-pie` to our executable linker flags. `-pie` is only applicable when linking executables and will fail on shared libraries since it cannot find a `main()` function. 

This MR solves this problem by introducing 2 new attributes to `configure_make()` and `make()`. 

* `executable_ldflags_vars`
* `shared_ldflags_vars`

Each is a string_list of variable names that the target project uses for executable ldflags and shared ldflags. For example, in openssl3 [BIN_LDFLAGS](https://github.com/openssl/openssl/blob/9884568569feb559cea2496a3326259a53db0860/Configurations/unix-Makefile.tmpl#L499) is used for executable ldflags and [LIB_LDFLAGS](https://github.com/openssl/openssl/blob/9884568569feb559cea2496a3326259a53db0860/Configurations/unix-Makefile.tmpl#L454) is used for shared ldflags.

by overwriting the respective *_LDFLAGS using make vars mapped to `cxx_linker_executable` and `cxx_shared_executable` we can enforce the mapping of appropriate linker flags.
