### PR TITLE
Fix dependency on platforms

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 bazel_dep(name = "bazel_features", version = "1.15.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
-bazel_dep(name = "platforms", version = "0.0.5")
+bazel_dep(name = "platforms", version = "0.0.9")
 bazel_dep(name = "rules_python", version = "0.23.1")
 
 # Dev dependencies

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -103,6 +103,16 @@ def rules_foreign_cc_dependencies(
 
     maybe(
         http_archive,
+        name = "platforms",
+        sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+        ],
+    )
+
+    maybe(
+        http_archive,
         name = "rules_python",
         sha256 = "84aec9e21cc56fbc7f1335035a71c850d1b9b5cc6ff497306f84cced9a769841",
         strip_prefix = "rules_python-0.23.1",


### PR DESCRIPTION
From https://github.com/bazelbuild/rules_foreign_cc/pull/1262#issuecomment-2289024681

> Its probably the non-bzlmod code path - we don't explicitly depend on platforms at the moment which I guess is a bug; you probably need to add platforms to the workspace macro in `rules_foreign_cc/repositories.bzl` too?

The goal of this PR is properly integrate platforms into rules_foreign_cc. Merging this will hopefully unblock #1262. I am setting this as a draft for now since I am a bit short on time to work on it and just want to see how CI behaves when I declare the repository.