### PR TITLE
correct overeager slash conversion on windows

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -335,7 +335,7 @@ def _convert_flags(compiler, flags):
         list: The converted flags
     """
     if compiler == "msvc-cl":
-        return [flag.replace("/", "-") if flag.startswith("/") else flag for flag in flags]
+        return [("-" + flag.removeprefix("/")) if flag.startswith("/") else flag for flag in flags]
     return flags
 
 def _add_if_needed(arr, add_arr):


### PR DESCRIPTION
Bazel's `File().path` method will return forward-slashed paths; this means if you pass a flag like `"/FI" + f.path` it'll end up looking like `/FIpath/to/thing`; however, `_convert_flags` was converting all `/` to `-`, which ended up breaking the path. This makes sure to only replace the _first_ `/`.