### PR TITLE
Introduce a configure_in_place equivalent for cmake rule

### DIFF
--- a/examples/cmake_generate_in_place/BUILD.bazel
+++ b/examples/cmake_generate_in_place/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["source_root/**"]),
+)
+
+cmake(
+    name = "liba",
+    generate_in_place = True,
+    lib_source = ":sources",
+)

--- a/examples/cmake_generate_in_place/source_root/CMakeLists.txt
+++ b/examples/cmake_generate_in_place/source_root/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(liba)
+
+set(LIBA_SRC src/liba.cpp src/liba.h)
+
+if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/src/liba.cpp)
+  message( FATAL_ERROR "${CMAKE_CURRENT_BINARY_DIR}/src/liba.cpp does not exist." )
+endif()
+
+add_library(liba_static STATIC ${LIBA_SRC})
+
+set_target_properties(liba_static PROPERTIES OUTPUT_NAME "liba")
+IF (WIN32)
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "liba")
+ELSE()
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "a")
+ENDIF()
+set_target_properties(liba_static PROPERTIES PUBLIC_HEADER "src/liba.h")
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(FILES src/liba.h DESTINATION include)
+
+install(TARGETS liba_static
+  EXPORT liba_targets
+  ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
+  PUBLIC_HEADER DESTINATION include
+  )
+target_include_directories(liba_static INTERFACE
+    $<INSTALL_INTERFACE:include>
+)
+
+install(EXPORT liba_targets
+  DESTINATION lib/cmake/liba
+  FILE liba-config.cmake)

--- a/examples/cmake_generate_in_place/source_root/src/liba.cpp
+++ b/examples/cmake_generate_in_place/source_root/src/liba.cpp
@@ -1,0 +1,5 @@
+#include "liba.h"
+
+std::string hello_liba(void) {
+  return "Hello from LIBA!";
+}

--- a/examples/cmake_generate_in_place/source_root/src/liba.h
+++ b/examples/cmake_generate_in_place/source_root/src/liba.h
@@ -1,0 +1,9 @@
+#ifndef LIBA_H_
+#define LIBA_H_ (1)
+
+#include <stdio.h>
+#include <string>
+
+std::string hello_liba(void);
+
+#endif

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -194,8 +194,6 @@ def _create_configure_script(configureParameters):
     inputs = configureParameters.inputs
 
     root = detect_root(ctx.attr.lib_source)
-    if len(ctx.attr.working_directory) > 0:
-        root = root + "/" + ctx.attr.working_directory
 
     tools = get_tools_info(ctx)
 
@@ -268,6 +266,8 @@ def _create_configure_script(configureParameters):
         user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data),
         options = attrs.generate_args,
         cmake_commands = cmake_commands,
+        generate_in_place = ctx.attr.generate_in_place,
+        working_directory = ctx.attr.working_directory,
         cmake_prefix = prefix,
         include_dirs = inputs.include_dirs,
         is_debug_mode = is_debug_mode(ctx),
@@ -384,6 +384,11 @@ def _attrs():
             ),
             mandatory = False,
             default = True,
+        ),
+        "generate_in_place": attr.bool(
+            doc = "If True, the `cmake` should be invoked in place, i.e. from it's enclosing directory and perform an in source build.",
+            mandatory = False,
+            default = False,
         ),
         "install": attr.bool(
             doc = "If True, the `cmake --install` comand will be performed after a build",

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -56,8 +56,8 @@ def create_cmake_script(
         user_env,
         options,
         cmake_commands,
-        generate_in_place,
-        working_directory,
+        generate_in_place = False,
+        working_directory = "",
         include_dirs = [],
         cmake_prefix = None,
         is_debug_mode = True):

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -150,26 +150,15 @@ def create_cmake_script(
 
     directory = "$$EXT_BUILD_ROOT$$/" + root
 
-    # normal route - external build dept + /external/cmake
-    # if generate in place
-    # if working with directory -> "."
-    # if working with directory -> "working directory"
-    # if no generate in place
-    # if working with directory -> "external build dept + root + cmake"
-    # if no working with directory -> external build dept + root
-
     if (generate_in_place):
         script.append("##copy_dir_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
-        directory = ""
 
-    if len(working_directory) > 0:
-        if len(directory) == 0:
+        if len(working_directory) > 0:
             directory = working_directory
         else:
-            directory = (directory + "/" + working_directory)
-
-    if len(directory) == 0:
-        directory = "."
+            directory = "."
+    elif len(working_directory) > 0:
+        directory = (directory + "/" + working_directory)
 
     script.append("##enable_tracing##")
 

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -56,6 +56,8 @@ def create_cmake_script(
         user_env,
         options,
         cmake_commands,
+        generate_in_place,
+        working_directory,
         include_dirs = [],
         cmake_prefix = None,
         is_debug_mode = True):
@@ -78,6 +80,8 @@ def create_cmake_script(
         user_env: dictionary with user's values for CMake environment variables
         options: other CMake options specified by user
         cmake_commands: A list of cmake commands for building and installing targets
+        generate_in_place: if True, the source root will be copied to the build directory and an in-source build will be performed.
+        working_directory: directory containing the main CMakeLists.txt
         include_dirs: Optional additional include directories. Defaults to [].
         cmake_prefix: Optional prefix before the cmake command (without the trailing space).
         is_debug_mode: If the compilation mode is `debug`. Defaults to True.
@@ -145,6 +149,27 @@ def create_cmake_script(
     script = set_env_vars
 
     directory = "$$EXT_BUILD_ROOT$$/" + root
+
+    # normal route - external build dept + /external/cmake
+    # if generate in place
+    # if working with directory -> "."
+    # if working with directory -> "working directory"
+    # if no generate in place
+    # if working with directory -> "external build dept + root + cmake"
+    # if no working with directory -> external build dept + root
+
+    if (generate_in_place):
+        script.append("##copy_dir_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
+        directory = ""
+
+    if len(working_directory) > 0:
+        if len(directory) == 0:
+            directory = working_directory
+        else:
+            directory = (directory + "/" + working_directory)
+
+    if len(directory) == 0:
+        directory = "."
 
     script.append("##enable_tracing##")
 


### PR DESCRIPTION
`cmake` versions above 2.35.5 introduces an issue described at https://gitlab.kitware.com/cmake/cmake/-/issues/26293 which copies symlinks in the sandbox to the build directory. 

When building with the `--experimental_guard_against_concurrent_changes` flag, outputs are not uploaded to the (remote) cache due to `WARNING: skipping uploading outputs because of concurrent modifications with --experimental_guard_against_concurrent_changes`. 

This can be reproduced via: https://github.com/rueteh/rfcc_cmake_build/tree/main and running `bazel build --disk_cache=/tmp/cache //:_cmake --sandbox_debug`. 

This MR aims to introduce a workaround until https://gitlab.kitware.com/utils/kwsys/-/merge_requests/303 is merged by copying the source files in the sandbox to the build directory, and performing an in-source cmake build, replicating the functionality of `configure_in_place` for the `configure_make` rule.