### PR TITLE
Improve flags handling for meson

### DIFF
--- a/examples/third_party/glib/BUILD.glib.bazel
+++ b/examples/third_party/glib/BUILD.glib.bazel
@@ -22,6 +22,13 @@ DEPS = [
 
 meson(
     name = "glib",
+    copts = select({
+        ":msvc_compiler": [
+            # This string is used as enum in gio/glib-compile-resources.c:718
+            "-UCOMPILER_MSVC",
+        ],
+        "//conditions:default": [],
+    }),
     env = select({
         ":msvc_compiler": {
             "INCLUDE": "$$EXT_BUILD_DEPS/include",

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -69,6 +69,7 @@ def _create_meson_script(configureParameters):
     inputs = configureParameters.inputs
 
     tools = get_tools_info(ctx)
+    flags = get_flags_info(ctx)
     script = pkgconfig_script(inputs.ext_build_dirs)
 
     # CFLAGS and CXXFLAGS are also set in foreign_cc/private/cmake_script.bzl, so that meson
@@ -81,20 +82,15 @@ def _create_meson_script(configureParameters):
     if " " not in tools.cxx:
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
 
-    # set flags same as foreign_cc/private/cc_toolchain_util.bzl
-    # cannot use get_flags_info() because bazel adds additional flags that
-    # aren't compatible with compiler or linker above
-    copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
-    cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
-
+    copts = flags.cc
+    cxxopts = flags.cxx
     if copts:
-        script.append("##export_var## CFLAGS \"{} ${{CFLAGS:-}}\"".format(" ".join(copts).replace("\"", "'")))
+        script.append("##export_var## CFLAGS \"{} ${{CFLAGS:-}}\"".format(_join_flags_list(ctx.workspace_name, copts).replace("\"", "'")))
     if cxxopts:
-        script.append("##export_var## CXXFLAGS \"{} ${{CXXFLAGS:-}}\"".format(" ".join(cxxopts).replace("\"", "'")))
+        script.append("##export_var## CXXFLAGS \"{} ${{CXXFLAGS:-}}\"".format(_join_flags_list(ctx.workspace_name, cxxopts).replace("\"", "'")))
 
-    flags = get_flags_info(ctx)
     if flags.cxx_linker_executable:
-        script.append("##export_var## LDFLAGS \"{} ${{LDFLAGS:-}}\"".format(" ".join(flags.cxx_linker_executable).replace("\"", "'")))
+        script.append("##export_var## LDFLAGS \"{} ${{LDFLAGS:-}}\"".format(_join_flags_list(ctx.workspace_name, flags.cxx_linker_executable).replace("\"", "'")))
 
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))
@@ -244,3 +240,6 @@ def _absolutize(workspace_name, text, force = False):
         return "\"{}\"".format(text)
 
     return absolutize_path_in_str(workspace_name, "$EXT_BUILD_ROOT/", text, force)
+
+def _join_flags_list(workspace_name, flags):
+    return " ".join([_absolutize(workspace_name, flag) for flag in flags])

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -236,9 +236,6 @@ def meson_with_requirements(name, requirements, **kwargs):
     )
 
 def _absolutize(workspace_name, text, force = False):
-    if text.strip(" ").startswith("C:") or text.strip(" ").startswith("c:"):
-        return "\"{}\"".format(text)
-
     return absolutize_path_in_str(workspace_name, "$EXT_BUILD_ROOT/", text, force)
 
 def _join_flags_list(workspace_name, flags):

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -383,7 +383,7 @@ def absolutize_path_in_str(workspace_name, root_str, text, force = False):
 
 def _prefix(text, from_str, prefix):
     (before, middle, after) = text.partition(from_str)
-    if not middle or before.endswith("/"):
+    if not middle or before.endswith("/") or before.endswith("\\"):
         return text
     return before + prefix + middle + after
 


### PR DESCRIPTION
This aligns this to what other tools are doing. The `_join_flags_list()` pattern is also used for other foreign build tools.

This is required to fix `--sysroot` flag even without cross compiling for example when using in combination with a hermetic toolchain (for example `toolchains_llvm`). This flag is only available in `get_flags_info()` and for the complicated ffmpeg build this works flawlessly. Without it being absolute, it doesn't work.

This is required to fix `libdav1d` in #1295.