### PR TITLE
fix: builds using preinstalled_make no longer break during pkgconfig

### DIFF
--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -88,7 +88,10 @@ def _pkgconfig_tool_impl(ctx):
         "%s install" % make_data.path,
     ]
 
-    additional_tools = depset(transitive = [make_data.target.files])
+    if make_data.target:
+        additional_tools = depset(transitive = [make_data.target.files])
+    else:
+        additional_tools = depset()
 
     return built_tool_rule_impl(
         ctx,


### PR DESCRIPTION
The target field on the make tool data should be None when using a preinstalled toolchain according to the docs, this fixes the pkgconfig tooling to handle that case.