### PR TITLE
add foreign_cc deps to cmake prefix path

### DIFF
--- a/examples/third_party/curl/BUILD.curl.bazel
+++ b/examples/third_party/curl/BUILD.curl.bazel
@@ -12,11 +12,9 @@ _CACHE_ENTRIES = {
     "BUILD_CURL_EXE": "off",
     "BUILD_SHARED_LIBS": "off",
     "CMAKE_BUILD_TYPE": "RELEASE",
-    "CMAKE_PREFIX_PATH": "$$EXT_BUILD_DEPS/openssl",
     "CMAKE_USE_OPENSSL": "on",
     # TODO: ldap should likely be enabled
     "CURL_DISABLE_LDAP": "on",
-    "OPENSSL_ROOT_DIR": "$$EXT_BUILD_DEPS/openssl",
 }
 
 _MACOS_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {

--- a/examples/third_party/libgit2/BUILD.libgit2.bazel
+++ b/examples/third_party/libgit2/BUILD.libgit2.bazel
@@ -13,7 +13,6 @@ _CACHE_ENTRIES = {
     "BUILD_EXAMPLES": "off",
     "BUILD_FUZZERS": "off",
     "BUILD_SHARED_LIBS": "off",
-    "CMAKE_PREFIX_PATH": "$$EXT_BUILD_DEPS/pcre;$$EXT_BUILD_DEPS/openssl;$$EXT_BUILD_DEPS/libssh2;$$EXT_BUILD_DEPS/zlib;$${CMAKE_PREFIX_PATH:-}",
     #"EMBED_SSH_PATH": "$(location @libssh2//:libssh2)",
     "USE_HTTPS": "on",
 }

--- a/examples/third_party/libssh2/BUILD.libssh2.bazel
+++ b/examples/third_party/libssh2/BUILD.libssh2.bazel
@@ -13,7 +13,6 @@ _CACHE_ENTRIES = {
     "BUILD_SHARED_LIBS": "off",
     "BUILD_TESTING": "off",
     "CMAKE_FIND_DEBUG_MODE": "on",
-    "CMAKE_PREFIX_PATH": "$${CMAKE_PREFIX_PATH:-};$$EXT_BUILD_DEPS/openssl",
 }
 
 _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -271,6 +271,7 @@ def _create_configure_script(configureParameters):
         cmake_prefix = prefix,
         include_dirs = inputs.include_dirs,
         is_debug_mode = is_debug_mode(ctx),
+        ext_build_dirs = inputs.ext_build_dirs,
     )
     return configure_script
 


### PR DESCRIPTION
see https://github.com/bazel-contrib/rules_foreign_cc/issues/887

Rather than creating a new provider, this MR utilizes `ForeignCcArtifactInfo:gen_dir` to add a `$$EXT_BUILD_DEPS/<package>`  to `CMAKE_PREFIX_PATH` for each external `ForeignCcDepsInfo`.

It eliminates the need for custom `CMAKE_PREFIX_PATH` or `<package>_ROOT` cache entries on `cmake` rules.