### PR TITLE
Remove deprecated use of incompatible_use_toolchain_transition

### DIFF
--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -61,7 +61,4 @@ boost_build = rule(
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
-    # version is updated to a release of Bazel containing the new default for this setting.
-    incompatible_use_toolchain_transition = True,
 )

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -421,9 +421,6 @@ cmake = rule(
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
     provides = [CcInfo],
-    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
-    # version is updated to a release of Bazel containing the new default for this setting.
-    incompatible_use_toolchain_transition = True,
 )
 
 def cmake_variant(name, toolchain, **kwargs):

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -246,9 +246,6 @@ configure_make = rule(
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
-    # version is updated to a release of Bazel containing the new default for this setting.
-    incompatible_use_toolchain_transition = True,
 )
 
 def configure_make_variant(name, toolchain, **kwargs):

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -132,9 +132,6 @@ make = rule(
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
-    # version is updated to a release of Bazel containing the new default for this setting.
-    incompatible_use_toolchain_transition = True,
 )
 
 def make_variant(name, toolchain, **kwargs):

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -198,9 +198,6 @@ meson = rule(
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
-    # version is updated to a release of Bazel containing the new default for this setting.
-    incompatible_use_toolchain_transition = True,
 )
 
 def meson_with_requirements(name, requirements, **kwargs):

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -118,7 +118,4 @@ ninja = rule(
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
-    # version is updated to a release of Bazel containing the new default for this setting.
-    incompatible_use_toolchain_transition = True,
 )

--- a/foreign_cc/private/transitions.bzl
+++ b/foreign_cc/private/transitions.bzl
@@ -38,7 +38,6 @@ extra_toolchains_transitioned_foreign_cc_target = rule(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
-    incompatible_use_toolchain_transition = True,
 )
 
 def foreign_cc_rule_variant(name, rule, toolchain, **kwargs):

--- a/toolchains/native_tools/native_tools_toolchain.bzl
+++ b/toolchains/native_tools/native_tools_toolchain.bzl
@@ -99,5 +99,4 @@ native_tool_toolchain = rule(
             allow_files = True,
         ),
     },
-    incompatible_use_toolchain_transition = True,
 )

--- a/toolchains/toolchains.bzl
+++ b/toolchains/toolchains.bzl
@@ -52,7 +52,6 @@ current_cmake_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:cmake_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:cmake_toolchain")),
     ],
@@ -63,7 +62,6 @@ current_make_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:make_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:make_toolchain")),
     ],
@@ -74,7 +72,6 @@ current_ninja_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:ninja_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:ninja_toolchain")),
     ],
@@ -85,7 +82,6 @@ current_meson_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:meson_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:meson_toolchain")),
     ],
@@ -96,7 +92,6 @@ current_autoconf_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:autoconf_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:autoconf_toolchain")),
     ],
@@ -107,7 +102,6 @@ current_automake_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:automake_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:automake_toolchain")),
     ],
@@ -118,7 +112,6 @@ current_m4_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:m4_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:m4_toolchain")),
     ],
@@ -129,7 +122,6 @@ current_pkgconfig_toolchain = rule(
     attrs = {
         "_toolchain": attr.string(default = str(Label("//toolchains:pkgconfig_toolchain"))),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = [
         str(Label("//toolchains:pkgconfig_toolchain")),
     ],


### PR DESCRIPTION
This is only necessary to support versions of Bazel prior to 5.0.0. According to the README, we only need to support Bazel 5.4.0 and later.