### PR TITLE
fix: move all bazelbuild links to bazel-contrib

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-"bazelbuild/rules_foreign_cc"
+"bazel-contrib/rules_foreign_cc"
 
 module(
     name = "rules_foreign_cc",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ variable](https://bazel.build/reference/be/make-variables)
 ## News
 
 For more generalized updates, please see [NEWS.md](./NEWS.md) or checkout the
-[release notes](https://github.com/bazelbuild/rules_foreign_cc/releases) of current or previous releases
+[release notes](https://github.com/bazel-contrib/rules_foreign_cc/releases) of current or previous releases
 
 ## Design document
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 # Rules ForeignCc Docs
 
-Up to date documentation can be found at: https://bazelbuild.github.io/rules_foreign_cc/
+Up to date documentation can be found at: https://bazel-contrib.github.io/rules_foreign_cc/
 
 ## Legacy documentation
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -2,4 +2,4 @@
 title = "Rules ForeignCc"
 
 [output.html]
-git-repository-url = "https://github.com/bazelbuild/rules_foreign_cc"
+git-repository-url = "https://github.com/bazel-contrib/rules_foreign_cc"

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Rules for building C/C++ projects using foreign build systems (non Bazel) inside
 
 | Release | Commit | Status |
 | --- | --------- | --- |
-| {release} | [{short_commit}](https://github.com/bazelbuild/rules_foreign_cc/commit/{commit}) | [![Build status](https://badge.buildkite.com/c28afbf846e2077715c753dda1f4b820cdcc46cc6cde16503c.svg?branch=main)](https://buildkite.com/bazel/rules-foreign-cc/builds?branch=main) |
+| {release} | [{short_commit}](https://github.com/bazel-contrib/rules_foreign_cc/commit/{commit}) | [![Build status](https://badge.buildkite.com/c28afbf846e2077715c753dda1f4b820cdcc46cc6cde16503c.svg?branch=main)](https://buildkite.com/bazel/rules-foreign-cc/builds?branch=main) |
 
 ## Overview
 
@@ -26,11 +26,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_foreign_cc",
     # TODO: Get the latest sha256 value from a bazel debug message or the latest 
-    #       release on the releases page: https://github.com/bazelbuild/rules_foreign_cc/releases
+    #       release on the releases page: https://github.com/bazel-contrib/rules_foreign_cc/releases
     #
     # sha256 = "...",
     strip_prefix = "rules_foreign_cc-{release_archive}",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/{release_archive}.tar.gz",
+    url = "https://github.com/bazel-contrib/rules_foreign_cc/archive/{release_archive}.tar.gz",
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")

--- a/docs/root/book.toml
+++ b/docs/root/book.toml
@@ -2,4 +2,4 @@
 title = "Rules ForeignCc"
 
 [output.html]
-git-repository-url = "https://github.com/bazelbuild/rules_foreign_cc"
+git-repository-url = "https://github.com/bazel-contrib/rules_foreign_cc"

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,6 +39,6 @@ A file containing a single macro `lib_repositories` that should define the desir
 `BUILD.lib.bazel` file will correctly be installed when the repository is setup. This macro will need to be
 loaded and called in [`third_party/repositories.bzl`](./third_party/repositories.bzl).
 
-[cmake_external]: https://github.com/bazelbuild/rules_foreign_cc/tree/main/docs#cmake_external
-[configure_make]: https://github.com/bazelbuild/rules_foreign_cc/tree/main/docs#configure_make
+[cmake_external]: https://github.com/bazel-contrib/rules_foreign_cc/tree/main/docs#cmake_external
+[configure_make]: https://github.com/bazel-contrib/rules_foreign_cc/tree/main/docs#configure_make
 [test_suite]: https://docs.bazel.build/versions/master/be/general.html#test_suite

--- a/examples/third_party/openssl/BUILD.openssl.bazel
+++ b/examples/third_party/openssl/BUILD.openssl.bazel
@@ -1,5 +1,5 @@
 """An openssl build file based on a snippet found in the github issue:
-https://github.com/bazelbuild/rules_foreign_cc/issues/337
+https://github.com/bazel-contrib/rules_foreign_cc/issues/337
 
 Note that the $(PERL) "make variable" (https://docs.bazel.build/versions/main/be/make-variables.html)
 is populated by the perl toolchain provided by rules_perl.

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -28,13 +28,13 @@ http_archive(
    name = "rules_foreign_cc",
    sha256 = "c2cdcf55ffaf49366725639e45dedd449b8c3fe22b54e31625eb80ce3a240f1e",
    strip_prefix = "rules_foreign_cc-0.1.0",
-   url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.1.0.zip",
+   url = "https://github.com/bazel-contrib/rules_foreign_cc/archive/0.1.0.zip",
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 # This sets up some common toolchains for building targets. For more details, please see
-# https://github.com/bazelbuild/rules_foreign_cc/tree/main/docs#rules_foreign_cc_dependencies
+# https://github.com/bazel-contrib/rules_foreign_cc/tree/main/docs#rules_foreign_cc_dependencies
 rules_foreign_cc_dependencies()
 
 _ALL_CONTENT = \"\"\"\\

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -125,8 +125,8 @@ def create_cmake_script(
 
     # Avoid CMake passing the wrong linker flags when cross compiling
     # by setting CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR,
-    # see https://github.com/bazelbuild/rules_foreign_cc/issues/289,
-    # and https://github.com/bazelbuild/rules_foreign_cc/pull/1062
+    # see https://github.com/bazel-contrib/rules_foreign_cc/issues/289,
+    # and https://github.com/bazel-contrib/rules_foreign_cc/pull/1062
     if target_os == "unknown":
         # buildifier: disable=print
         print("target_os is unknown, please update foreign_cc/private/framework/platform.bzl and foreign_cc/private/cmake_script.bzl; triggered by", current_label)


### PR DESCRIPTION
Update links after the repo transfer (#1290).

Fixes #1297