### PR TITLE
fix: docs pages

### DIFF
--- a/.github/docs-0.1.0.patch
+++ b/.github/docs-0.1.0.patch
@@ -40,3 +40,16 @@ index 0000000..98bb722
 +"""A module represeting the version of rules_foreign_cc"""
 +
 +VERSION = "0.1.0"
+diff --git a/docs/.bazelrc b/docs/.bazelrc
+new file mode 100644
+index 0000000..9eb0697
+--- /dev/null
++++ b/docs/.bazelrc
+@@ -0,0 +1,7 @@
++# Bazel configuration flags for rules_foreign_cc_docs
++
++# https://github.com/bazelbuild/stardoc/issues/112
++common --incompatible_allow_tags_propagation
++
++common --noenable_bzlmod
++build --workspace_status_command=tools/workspace_status.sh

--- a/.github/docs-0.10.1.patch
+++ b/.github/docs-0.10.1.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.2.0.patch
+++ b/.github/docs-0.2.0.patch
@@ -40,3 +40,16 @@ index 0000000..98bb722
 +"""A module represeting the version of rules_foreign_cc"""
 +
 +VERSION = "0.2.0"
+diff --git a/docs/.bazelrc b/docs/.bazelrc
+new file mode 100644
+index 0000000..9eb0697
+--- /dev/null
++++ b/docs/.bazelrc
+@@ -0,0 +1,7 @@
++# Bazel configuration flags for rules_foreign_cc_docs
++
++# https://github.com/bazelbuild/stardoc/issues/112
++common --incompatible_allow_tags_propagation
++
++common --noenable_bzlmod
++build --workspace_status_command=tools/workspace_status.sh

--- a/.github/docs-0.3.0.patch
+++ b/.github/docs-0.3.0.patch
@@ -80,3 +80,16 @@ index 0000000..98bb722
 +"""A module represeting the version of rules_foreign_cc"""
 +
 +VERSION = "0.3.0"
+diff --git a/docs/.bazelrc b/docs/.bazelrc
+new file mode 100644
+index 0000000..9eb0697
+--- /dev/null
++++ b/docs/.bazelrc
+@@ -0,0 +1,7 @@
++# Bazel configuration flags for rules_foreign_cc_docs
++
++# https://github.com/bazelbuild/stardoc/issues/112
++common --incompatible_allow_tags_propagation
++
++common --noenable_bzlmod
++build --workspace_status_command=tools/workspace_status.sh

--- a/.github/docs-0.5.0.patch
+++ b/.github/docs-0.5.0.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.5.1.patch
+++ b/.github/docs-0.5.1.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.6.0.patch
+++ b/.github/docs-0.6.0.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.7.0.patch
+++ b/.github/docs-0.7.0.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.7.1.patch
+++ b/.github/docs-0.7.1.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.8.0.patch
+++ b/.github/docs-0.8.0.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/docs-0.9.0.patch
+++ b/.github/docs-0.9.0.patch
@@ -1,16 +1,3 @@
-diff --git a/docs/BUILD.bazel b/docs/BUILD.bazel
-index 2bdbf6e..418dd13 100644
---- a/docs/BUILD.bazel
-+++ b/docs/BUILD.bazel
-@@ -97,7 +97,7 @@ set -euo pipefail
- short_commit="$${SHORT_COMMIT}"
- commit="$${COMMIT}"
- release="$${RELEASE}"
--if [[ -n "\\$${RELEASE}" ]]; then
-+if [[ -n "\\$${RELEASE:-}" ]]; then
-     release="\\$${RELEASE}"
- fi
- mkdir -p \\$${BUILD_WORKSPACE_DIRECTORY}/src
 diff --git a/docs/.bazelrc b/docs/.bazelrc
 index dc6a3f7..9eb0697 100644
 --- a/docs/.bazelrc

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -17,6 +17,9 @@ jobs:
         # Create a job for release
         include:
           - ref: main
+          - ref: "0.12.0"
+          - ref: "0.11.1"
+          - ref: "0.11.0"
           - ref: "0.10.1"
           - ref: "0.9.0"
           - ref: "0.8.0"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -44,10 +44,19 @@ jobs:
         if: ${{ matrix.ref == 'main' }}
       - name: Patch older branches
         run: |
+          ref="${{ matrix.ref }}"
+
+          [[ "$ref" == "main" ]] && exit
+
+          v_major="$(echo "$ref" | cut -d. -f1)"
+          v_minor="$(echo "$ref" | cut -d. -f2)"
+          v_patch="$(echo "$ref" | cut -d. -f3)"
+
+          [[ $v_major -gt 10 ]] && exit
+
           mkdir -p ${{ github.workspace }}/.github
           curl https://raw.githubusercontent.com/bazel-contrib/rules_foreign_cc/main/.github/docs-${{ matrix.ref }}.patch > ${{ github.workspace }}/.github/docs-${{ matrix.ref }}.patch
           git apply ${{ github.workspace }}/.github/docs-${{ matrix.ref }}.patch
-        if: ${{ matrix.ref == '0.4.0' || matrix.ref == '0.3.0' || matrix.ref == '0.2.0' || matrix.ref == '0.1.0' }}
       - name: Install bazelisk
         run: |
           curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.9.0/bazelisk-linux-amd64"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -67,7 +67,7 @@ jobs:
         run: ${{ github.workspace }}/bin/mdbook build
         working-directory: ${{ github.workspace }}/docs
       - name: Save the newly built book
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.ref }}"
           path: ${{ github.workspace }}/docs/book
@@ -78,7 +78,7 @@ jobs:
         if: ${{ matrix.ref == 'main' }}
         working-directory: ${{ github.workspace }}/docs/root
       - name: Save the newly built book
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ matrix.ref }}-root"
           path: ${{ github.workspace }}/docs/root/book

--- a/docs/root/src/index.md
+++ b/docs/root/src/index.md
@@ -5,6 +5,9 @@ Rules for building C/C++ projects using foreign build systems (non Bazel) inside
 ## Versions
 
 - [main](main/index.md)
+- [0.12.0](0.12.0/index.md)
+- [0.11.1](0.11.1/index.md)
+- [0.11.0](0.11.0/index.md)
 - [0.10.1](0.10.1/index.md)
 - [0.9.0](0.9.0/index.md)
 - [0.8.0](0.8.0/index.md)

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """A module represeting the version of rules_foreign_cc"""
 
-VERSION = "0.9.0"
+VERSION = "0.12.0"


### PR DESCRIPTION
### fix: deprecated versions of actions/upload-artifact

The [pages workflow is failing](https://github.com/bazel-contrib/rules_foreign_cc/actions/runs/11706830028/job/32604817856) due to deprecated versions of actions/upload-artifact.

I believe this is why the docs are not updating (e.g. the Meson docs are still blank after #1060 landed).

For more info, see:
 * https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
 * https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
 * https://github.com/actions/upload-artifact
 
### chore: bump version.bzl to the current released version
This is also needed for docs generation, see `docs/tools/workspace_status.sh`

### docs: update releases