### PR TITLE
fix: move more bazelbuild links to bazel-contrib

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -24,7 +24,7 @@ tasks:
       - "//..."
     test_targets:
       - "//..."
-      # TODO: https://github.com/bazelbuild/rules_foreign_cc/issues/495
+      # TODO: https://github.com/bazel-contrib/rules_foreign_cc/issues/495
       - "-//test:shell_method_symlink_contents_to_dir_test"
       - "-//test:shell_script_inner_fun_test"
     build_flags:

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -7,7 +7,7 @@
       "name": "James Sharpe"
     }
   ],
-  "repository": ["github:bazelbuild/rules_foreign_cc"],
+  "repository": ["github:bazel-contrib/rules_foreign_cc"],
   "versions": [],
   "yanked_versions": {}
 }

--- a/.github/docs-0.1.0.patch
+++ b/.github/docs-0.1.0.patch
@@ -21,7 +21,7 @@ index 0000000..5096728
 +title = "Rules ForeignCc"
 +
 +[output.html]
-+git-repository-url = "https://github.com/bazelbuild/rules_foreign_cc"
++git-repository-url = "https://github.com/bazel-contrib/rules_foreign_cc"
 diff --git a/docs/src/SUMMARY.md b/docs/src/SUMMARY.md
 new file mode 100644
 index 0000000..69fbd4d

--- a/.github/docs-0.2.0.patch
+++ b/.github/docs-0.2.0.patch
@@ -21,7 +21,7 @@ index 0000000..5096728
 +title = "Rules ForeignCc"
 +
 +[output.html]
-+git-repository-url = "https://github.com/bazelbuild/rules_foreign_cc"
++git-repository-url = "https://github.com/bazel-contrib/rules_foreign_cc"
 diff --git a/docs/src/SUMMARY.md b/docs/src/SUMMARY.md
 new file mode 100644
 index 0000000..69fbd4d

--- a/.github/docs-0.3.0.patch
+++ b/.github/docs-0.3.0.patch
@@ -36,7 +36,7 @@ index 0000000..5096728
 +title = "Rules ForeignCc"
 +
 +[output.html]
-+git-repository-url = "https://github.com/bazelbuild/rules_foreign_cc"
++git-repository-url = "https://github.com/bazel-contrib/rules_foreign_cc"
 diff --git a/docs/index.md b/docs/index.md
 index 3a91e41..14c8e3b 100644
 --- a/docs/index.md
@@ -47,13 +47,13 @@ index 3a91e41..14c8e3b 100644
      name = "rules_foreign_cc",
 -    sha256 = "d54742ffbdc6924f222d2179f0e10e911c5c659c4ae74158e9fe827aad862ac6",
 -    strip_prefix = "rules_foreign_cc-0.2.0",
--    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.2.0.tar.gz",
+-    url = "https://github.com/bazel-contrib/rules_foreign_cc/archive/0.2.0.tar.gz",
 +    # TODO: Get the latest sha256 value from the latest release on the releases page
-+    #       https://github.com/bazelbuild/rules_foreign_cc/releases
++    #       https://github.com/bazel-contrib/rules_foreign_cc/releases
 +    #
 +    # sha256 = "...",
 +    strip_prefix = "rules_foreign_cc-0.3.0",
-+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.3.0.tar.gz",
++    url = "https://github.com/bazel-contrib/rules_foreign_cc/archive/0.3.0.tar.gz",
  )
  
  load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Patch older branches
         run: |
           mkdir -p ${{ github.workspace }}/.github
-          curl https://raw.githubusercontent.com/bazelbuild/rules_foreign_cc/main/.github/docs-${{ matrix.ref }}.patch > ${{ github.workspace }}/.github/docs-${{ matrix.ref }}.patch
+          curl https://raw.githubusercontent.com/bazel-contrib/rules_foreign_cc/main/.github/docs-${{ matrix.ref }}.patch > ${{ github.workspace }}/.github/docs-${{ matrix.ref }}.patch
           git apply ${{ github.workspace }}/.github/docs-${{ matrix.ref }}.patch
         if: ${{ matrix.ref == '0.4.0' || matrix.ref == '0.3.0' || matrix.ref == '0.2.0' || matrix.ref == '0.1.0' }}
       - name: Install bazelisk

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -31,7 +31,7 @@ http_archive(
     name = "rules_foreign_cc",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/${TAG}/${ARCHIVE}",
+    url = "https://github.com/bazel-contrib/rules_foreign_cc/releases/download/${TAG}/${ARCHIVE}",
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")


### PR DESCRIPTION
I missed some links in #1315 😕

I was using `rg` to grep and I forgot that it will respect `.gitignore` and exclude those files.

I hope I got them all this time!