### PR TITLE
msvc: fix make var for windows deps

### DIFF
--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -2,6 +2,7 @@
 build tool
 """
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
     "get_flags_info",
@@ -82,6 +83,9 @@ def _create_configure_script(configureParameters):
     if xcompile_options:
         configure_options.extend(xcompile_options)
 
+    cc_toolchain = find_cpp_toolchain(ctx)
+    is_msvc = cc_toolchain.compiler == "msvc-cl"
+
     configure = create_configure_script(
         workspace_name = ctx.workspace_name,
         tools = tools,
@@ -108,6 +112,7 @@ def _create_configure_script(configureParameters):
         make_args = args,
         executable_ldflags_vars = ctx.attr.executable_ldflags_vars,
         shared_ldflags_vars = ctx.attr.shared_ldflags_vars,
+        is_msvc = is_msvc,
     )
     return define_install_prefix + configure
 

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -1,5 +1,6 @@
 """A rule for building projects using the [GNU Make](https://www.gnu.org/software/make/) build tool"""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
     "get_flags_info",
@@ -66,6 +67,9 @@ def _create_make_script(configureParameters):
             install_prefix = ctx.attr.install_prefix,
         ))
 
+    cc_toolchain = find_cpp_toolchain(ctx)
+    is_msvc = cc_toolchain.compiler == "msvc-cl"
+
     return create_make_script(
         workspace_name = ctx.workspace_name,
         tools = tools,
@@ -81,6 +85,7 @@ def _create_make_script(configureParameters):
         make_install_prefix = ctx.attr.install_prefix,
         executable_ldflags_vars = ctx.attr.executable_ldflags_vars,
         shared_ldflags_vars = ctx.attr.shared_ldflags_vars,
+        is_msvc = is_msvc,
     )
 
 def _attrs():

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -28,7 +28,8 @@ def create_configure_script(
         make_targets,
         make_args,
         executable_ldflags_vars,
-        shared_ldflags_vars):
+        shared_ldflags_vars,
+        is_msvc):
     ext_build_dirs = inputs.ext_build_dirs
 
     script = pkgconfig_script(ext_build_dirs)
@@ -73,15 +74,17 @@ def create_configure_script(
         ).lstrip())
 
     script.append("##mkdirs## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$")
+
+    make_commands = []
     script.append("{env_vars} {prefix}\"{configure}\" {prefix_flag}$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
-        env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),
+        env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, is_msvc, make_commands),
         prefix = configure_prefix,
         configure = configure_path,
         prefix_flag = prefix_flag,
         user_options = " ".join(user_options),
     ))
 
-    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs)
+    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs, is_msvc)
 
     make_commands = []
     for target in make_targets:

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -17,7 +17,8 @@ def create_make_script(
         make_args,
         make_install_prefix,
         executable_ldflags_vars,
-        shared_ldflags_vars):
+        shared_ldflags_vars,
+        is_msvc):
     ext_build_dirs = inputs.ext_build_dirs
 
     script = pkgconfig_script(ext_build_dirs)
@@ -26,7 +27,7 @@ def create_make_script(
 
     script.append("##enable_tracing##")
 
-    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs)
+    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs, is_msvc)
 
     make_commands = []
     for target in make_targets:
@@ -39,7 +40,7 @@ def create_make_script(
             install_prefix = make_install_prefix,
         ))
 
-    configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, make_commands)
+    configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, is_msvc, make_commands)
 
     script.extend(["{env_vars} {command}".format(
         env_vars = configure_vars,


### PR DESCRIPTION
Linker make vars generated for dependent packages used -L which is not supported on msvc. -LIBPATH is needed.