### PR TITLE
framework: avoid forced path suffixing

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -724,11 +724,23 @@ def _correct_path_variable(toolchain, env):
                 corrected_env[key] = ";".join(path_paths)
         env = corrected_env
 
-    value = env.get("PATH", "")
-    if not value:
+    value = env.get("PATH")
+    if value == None:
+        # avoid setting PATH if it isn't set, and vice-versa
         return env
-    value = _normalize_path(env.get("PATH", ""))
-    env["PATH"] = "$PATH:" + value
+
+    value = _normalize_path(value)
+
+    if "$PATH" not in value:
+        # Since we end up overriding the value of PATH here, we need to make
+        # sure we preserve the current value of the PATH (in case
+        # strict_action_env is not in use).  If one of the toolchains has
+        # already overridden where the PATH self-reference falls (in order to
+        # put toolchain items first, for example) we want to trust that, but
+        # otherwise we need to make sure it's referenced _somewhere_.
+        value = "$PATH:" + value
+
+    env["PATH"] = value
     return env
 
 def _list(item):


### PR DESCRIPTION
Calling foreign build systems can be fraught, since a lot of custom-written rules do things like execute gcc from the path, instead of using the CC variable. This makes PATH ordering important, to make sure that even if that happens, the toolchain tools get used anyway (and not, e.g. from /usr/bin)

One way to handle that at the toolchain level is to use env_entries (e.g.
https://github.com/bazelbuild/rules_cc/blob/8c94e11c2b05b5f25ced5f23cd07d0cdd36edc1a/cc/private/toolchain/windows_cc_toolchain_config.bzl#L1246) to add the toolchain to the path. You can control whether the toolchain gets prepended or appended by using the token $PATH, e.g. /my/path:$PATH vs $PATH:/my/path.

Unfortunately, the _correct_path_variable helper was unconditionally prepending $PATH to the toolchain path, even though it had just retrieved the value of PATH and no longer needed the original value, making it impossible for the toolchain to prepend a path.