### PR TITLE
fix sysroot for make and pkgconfig built tools

### DIFF
--- a/foreign_cc/built_tools/make_build.bzl
+++ b/foreign_cc/built_tools/make_build.bzl
@@ -8,6 +8,8 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "absolutize",
     "built_tool_rule_impl",
+    "extract_non_sysroot_flags",
+    "extract_sysroot_flags",
 )
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
@@ -46,13 +48,13 @@ def _make_tool_impl(ctx):
 
         cc_path = tools_info.cc
         cflags = flags_info.cc
-        sysroot_cflags = [flag for flag in cflags if flag.startswith("--sysroot=")]
-        non_sysroot_cflags = [flag for flag in cflags if not flag.startswith("--sysroot=")]
+        sysroot_cflags = extract_sysroot_flags(cflags)
+        non_sysroot_cflags = extract_non_sysroot_flags(cflags)
 
         ld_path = tools_info.cxx_linker_executable
         ldflags = flags_info.cxx_linker_executable
-        sysroot_ldflags = [flag for flag in ldflags if flag.startswith("--sysroot=")]
-        non_sysroot_ldflags = [flag for flag in ldflags if not flag.startswith("--sysroot=")]
+        sysroot_ldflags = extract_sysroot_flags(ldflags)
+        non_sysroot_ldflags = extract_non_sysroot_flags(ldflags)
 
         # Make's build script does not forward CFLAGS to all compiler and linker
         # invocations, so we append --sysroot flags directly to CC and LD.

--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -8,6 +8,8 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "absolutize",
     "built_tool_rule_impl",
+    "extract_non_sysroot_flags",
+    "extract_sysroot_flags",
 )
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
@@ -29,13 +31,13 @@ def _pkgconfig_tool_impl(ctx):
 
     cc_path = tools_info.cc
     cflags = flags_info.cc + ["-Wno-int-conversion"]  # Fix building with clang 15+
-    sysroot_cflags = [flag for flag in cflags if flag.startswith("--sysroot=")]
-    non_sysroot_cflags = [flag for flag in cflags if not flag.startswith("--sysroot=")]
+    sysroot_cflags = extract_sysroot_flags(cflags)
+    non_sysroot_cflags = extract_non_sysroot_flags(cflags)
 
     ld_path = tools_info.cxx_linker_executable
     ldflags = flags_info.cxx_linker_executable
-    sysroot_ldflags = [flag for flag in ldflags if flag.startswith("--sysroot=")]
-    non_sysroot_ldflags = [flag for flag in ldflags if not flag.startswith("--sysroot=")]
+    sysroot_ldflags = extract_sysroot_flags(ldflags)
+    non_sysroot_ldflags = extract_non_sysroot_flags(ldflags)
 
     # Make's build script does not forward CFLAGS to all compiler and linker
     # invocations, so we append --sysroot flags directly to CC and LD.

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -50,6 +50,48 @@ FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS = [
 def absolutize(workspace_name, text, force = False):
     return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
 
+def extract_sysroot_flags(flags):
+    """Function to return sysroot args from list of flags like cflags or ldflags
+
+    sysroot args are either '--sysroot=</path/to/sysroot>' or '--sysroot </path/to/sysroot>'
+
+    Args:
+        flags (list): list of flags
+
+    Returns:
+        List of sysroot flags
+    """
+    ret_flags = []
+    for i in range(len(flags)):
+        if flags[i] == "--sysroot":
+            if i + 1 < len(flags):
+                ret_flags.append(flags[i])
+                ret_flags.append(flags[i + 1])
+        elif flags[i].startswith("--sysroot="):
+            ret_flags.append(flags[i])
+    return ret_flags
+
+def extract_non_sysroot_flags(flags):
+    """Function to return non sysroot args from list of flags like cflags or ldflags
+
+    sysroot args are either '--sysroot=</path/to/sysroot>' or '--sysroot </path/to/sysroot>'
+
+    Args:
+        flags (list): list of flags
+
+    Returns:
+        List of non sysroot flags
+    """
+    ret_flags = []
+    for i in range(len(flags)):
+        if flags[i] == "--sysroot" or \
+           flags[i].startswith("--sysroot=") or \
+           (i != 0 and flags[i - 1] == "--sysroot"):
+            continue
+        else:
+            ret_flags.append(flags[i])
+    return ret_flags
+
 def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic, additional_tools = None):
     """Framework function for bootstrapping C/C++ build tools.
 


### PR DESCRIPTION
sysroot can be specified with as `--sysroot=<meow>` or `--sysroot <meow>`. This fix allows for the latter use case as well.