### PR TITLE
Set CMAKE_OSX_SYSROOT automatically

### DIFF
--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -313,6 +313,7 @@ def _fill_crossfile_from_toolchain(workspace_name, tools, flags, target_os):
     _sysroot = _find_in_cc_or_cxx(flags, "sysroot")
     if _sysroot:
         dict["CMAKE_SYSROOT"] = _absolutize(workspace_name, _sysroot)
+        dict["CMAKE_OSX_SYSROOT"] = _absolutize(workspace_name, _sysroot)
 
     _ext_toolchain_cc = _find_flag_value(flags.cc, "gcc_toolchain")
     if _ext_toolchain_cc:


### PR DESCRIPTION
On macOS if you have a hermetic sysroot this variable overrides
CMAKE_SYSROOT and cmake instead just searches for Xcode
