### PR TITLE
cmake: put CMAKE_SYSTEM_{NAME,PROCESSOR} into toolchain file

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -148,6 +148,7 @@ load(
 load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
 load(
     "//foreign_cc/private/framework:platform.bzl",
+    "arch_name",
     "os_name",
     "target_arch_name",
     "target_os_name",
@@ -259,6 +260,7 @@ def _create_configure_script(configureParameters):
         target_os = target_os_name(ctx),
         target_arch = target_arch_name(ctx),
         host_os = os_name(ctx),
+        host_arch = arch_name(ctx),
         generator = attrs.generator,
         cmake_path = attrs.cmake_path,
         tools = tools,

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -45,6 +45,7 @@ def create_cmake_script(
         target_os,
         target_arch,
         host_os,
+        host_arch,
         generator,
         cmake_path,
         tools,
@@ -68,6 +69,7 @@ def create_cmake_script(
         target_os: The target OS for the build
         target_arch: The target arch for the build
         host_os: The execution OS for the build
+        host_arch: The execution arch for the build
         generator: The generator target for cmake to use
         cmake_path: The path to the cmake executable
         tools: cc_toolchain tools (CxxToolsInfo)
@@ -92,6 +94,23 @@ def create_cmake_script(
 
     toolchain_dict = _fill_crossfile_from_toolchain(workspace_name, tools, flags, target_os)
     params = None
+
+    # Avoid CMake passing the wrong linker flags when cross compiling
+    # by setting CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR,
+    # see https://github.com/bazel-contrib/rules_foreign_cc/issues/289,
+    # and https://github.com/bazel-contrib/rules_foreign_cc/pull/1062
+    # note: these parameters must be set in the toolchain file, not just in the
+    # cache, and CMAKE_SYSTEM_PROCESSOR is ignored unless CMAKE_SYSTEM_NAME is
+    # also set.
+    if target_os == "unknown":
+        # buildifier: disable=print
+        print("target_os is unknown, please update foreign_cc/private/framework/platform.bzl and foreign_cc/private/cmake_script.bzl; triggered by", current_label)
+    elif target_arch == "unknown":
+        # buildifier: disable=print
+        print("target_arch is unknown, please update foreign_cc/private/framework/platform.bzl and foreign_cc/private/cmake_script.bzl; triggered by", current_label)
+    elif target_os != host_os or target_arch != host_arch:
+        toolchain_dict.update(_TARGET_OS_PARAMS.get(target_os, {}))
+        toolchain_dict.update(_TARGET_ARCH_PARAMS.get(target_arch, {}))
 
     keys_with_empty_values_in_user_cache = [key for key in user_cache if user_cache.get(key) == ""]
 
@@ -122,17 +141,6 @@ def create_cmake_script(
     # see https://github.com/envoyproxy/envoy/pull/6991
     if not params.cache.get("CMAKE_RANLIB"):
         params.cache.update({"CMAKE_RANLIB": ""})
-
-    # Avoid CMake passing the wrong linker flags when cross compiling
-    # by setting CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR,
-    # see https://github.com/bazel-contrib/rules_foreign_cc/issues/289,
-    # and https://github.com/bazel-contrib/rules_foreign_cc/pull/1062
-    if target_os == "unknown":
-        # buildifier: disable=print
-        print("target_os is unknown, please update foreign_cc/private/framework/platform.bzl and foreign_cc/private/cmake_script.bzl; triggered by", current_label)
-    elif target_os != host_os:
-        params.cache.update(_TARGET_OS_PARAMS.get(target_os, {}))
-        params.cache.update(_TARGET_ARCH_PARAMS.get(target_arch, {}))
 
     set_env_vars = [
         "export {}=\"{}\"".format(key, _escape_dquote_bash(params.env[key]))
@@ -194,6 +202,7 @@ _CMAKE_ENV_VARS_FOR_CROSSTOOL = {
 }
 
 _CMAKE_CACHE_ENTRIES_CROSSTOOL = {
+    "ANDROID": struct(value = "ANDROID", replace = False),
     "CMAKE_AR": struct(value = "CMAKE_AR", replace = True),
     "CMAKE_ASM_FLAGS": struct(value = "CMAKE_ASM_FLAGS_INIT", replace = False),
     "CMAKE_CXX_ARCHIVE_CREATE": struct(value = "CMAKE_CXX_ARCHIVE_CREATE", replace = False),
@@ -206,6 +215,8 @@ _CMAKE_CACHE_ENTRIES_CROSSTOOL = {
     "CMAKE_RANLIB": struct(value = "CMAKE_RANLIB", replace = True),
     "CMAKE_SHARED_LINKER_FLAGS": struct(value = "CMAKE_SHARED_LINKER_FLAGS_INIT", replace = False),
     "CMAKE_STATIC_LINKER_FLAGS": struct(value = "CMAKE_STATIC_LINKER_FLAGS_INIT", replace = False),
+    "CMAKE_SYSTEM_NAME": struct(value = "CMAKE_SYSTEM_NAME", replace = False),
+    "CMAKE_SYSTEM_PROCESSOR": struct(value = "CMAKE_SYSTEM_PROCESSOR", replace = False),
 }
 
 def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -256,6 +256,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         "unknown",
         "unknown",
         "unknown",
+        "unknown",
         "Unix Makefiles",
         "cmake",
         tools,
@@ -306,6 +307,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
     script = create_cmake_script(
         "ws",
         ctx.label,
+        "unknown",
         "unknown",
         "unknown",
         "unknown",
@@ -369,6 +371,7 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
         "unknown",
         "unknown",
         "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -419,6 +422,7 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
     script = create_cmake_script(
         "ws",
         ctx.label,
+        "unknown",
         "unknown",
         "unknown",
         "unknown",
@@ -505,6 +509,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
         "unknown",
         "unknown",
         "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -573,6 +578,7 @@ def _create_cmake_script_android_test(ctx):
         "android",
         "x86_64",
         "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -592,7 +598,7 @@ export CXXFLAGS="--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain
 export ASMFLAGS="assemble assemble-user"
 export CUSTOM_ENV="YES"
 ##enable_tracing##
-cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_MODULE_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DANDROID="YES" -DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSTEM_PROCESSOR="x86_64" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_MODULE_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DANDROID="YES" -DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSTEM_PROCESSOR="x86_64" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 ##disable_tracing##
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -641,6 +647,7 @@ def _create_cmake_script_linux_test(ctx):
         "linux",
         "aarch64",
         "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -660,7 +667,7 @@ export CXXFLAGS="--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain
 export ASMFLAGS="assemble assemble-user"
 export CUSTOM_ENV="YES"
 ##enable_tracing##
-cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_MODULE_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSTEM_PROCESSOR="aarch64" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_MODULE_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSTEM_PROCESSOR="aarch64" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 ##disable_tracing##
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -705,6 +712,7 @@ def _create_cmake_script_toolchain_file_test(ctx):
     script = create_cmake_script(
         "ws",
         ctx.label,
+        "unknown",
         "unknown",
         "unknown",
         "unknown",


### PR DESCRIPTION
For some projects, it's sufficient to just have these in the cache, but for abseil, it appears to break unless they're in the toolchain file. The error is similar to the one in [this bug](https://github.com/abseil/abseil-cpp/issues/1241) where it tries to use x64 flags for an aarch64 target.

The [cmake docs](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html#toolchain-files) also indicate they're supposed to be in the toolchain file, so this aligns there, too.