### PR TITLE
add a static_suffix attr

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -67,7 +67,7 @@ def _configure_features(ctx, cc_toolchain):
 def _create_libraries_to_link(ctx, files):
     libs = []
 
-    static_map = _files_map(_filter(files.static_libraries or [], _is_position_independent, True))
+    static_map = _files_map(_filter(files.static_libraries or [], _is_position_independent, True), suffix = ctx.attr.static_suffix)
     pic_static_map = _files_map(_filter(files.static_libraries or [], _is_position_independent, False))
     shared_map = _files_map(files.shared_libraries or [])
     interface_map = _files_map(files.interface_libraries or [])
@@ -106,10 +106,10 @@ def _filter(list_, predicate, inverse):
             result.append(elem)
     return result
 
-def _files_map(files_list):
+def _files_map(files_list, suffix = ""):
     by_names_map = {}
     for file_ in files_list:
-        name_ = _file_name_no_ext(file_.basename)
+        name_ = _removesuffix(_file_name_no_ext(file_.basename), suffix)
         value = by_names_map.get(name_)
         if value:
             fail("Can not have libraries with the same name in the same category")
@@ -390,3 +390,6 @@ def _prefix(text, from_str, prefix):
 def _file_name_no_ext(basename):
     (before, _separator, _after) = basename.rpartition(".")
     return before
+
+def _removesuffix(s, sub):
+    return s[:-len(sub)] if sub and s.endswith(sub) else s

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -210,6 +210,13 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         mandatory = False,
         default = False,
     ),
+    "static_suffix": attr.string(
+        doc = (
+            "Optional suffix used by static libs." +
+            "Ensures correct association of static and shared libs."
+        ),
+        mandatory = False,
+    ),
     "targets": attr.string_list(
         doc = (
             "A list of targets with in the foreign build system to produce. An empty string (`\"\"`) will result in " +


### PR DESCRIPTION
Some third party cmake packages append a suffix to static libs eg. cares:

```
out_shared_libs = [
    "libcares.so",
],
out_static_libs = [
    "libcares_static.a",
]
```
`cmake` will treat these as separate libs, creating separate `CcInfo` `<LibraryToLink>`'s for each:

```
 <LinkerInput(libraries=[<LibraryToLink(static_library=libcares_static.a)>, <LibraryToLink(dynamic_library=libcares.so)>]>
 ```
This creates a different `linking_context` compared to packages that have matching filenames, and can lead to changes in linking behavior when used as a dep.

 This change introduces a new attribute `static_suffix` that provides a hint to allow association of the suffix-appended static lib with the shared lib:
 
 ```
 static_suffix = "_static",
 ```
 results in
 ```
 <LinkerInput(libraries=[<LibraryToLink(static_library=libcares_static.a, dynamic_library=libcares.so)>]>
 ```
