### PR TITLE
add xcompile support for ppc64le for autotools and cmake

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -12,7 +12,7 @@ use_repo(
     "meson_src",
 )
 
-bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_rust", version = "0.56.0")
 bazel_dep(name = "rules_swift", version = "1.6.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "rules_apple", version = "3.4.0", repo_name = "build_bazel_rules_apple")

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -31,6 +31,9 @@ _TARGET_ARCH_PARAMS = {
     "aarch64": {
         "CMAKE_SYSTEM_PROCESSOR": "aarch64",
     },
+    "ppc64le": {
+        "CMAKE_SYSTEM_PROCESSOR": "ppc64le",
+    },
     "s390x": {
         "CMAKE_SYSTEM_PROCESSOR": "s390x",
     },

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -2,6 +2,7 @@
 
 SUPPORTED_CPU = [
     "aarch64",
+    "ppc64le",
     "s390x",
     "x86_64",
 ]
@@ -183,6 +184,8 @@ def triplet_name(os, arch):
         # consistently, I don't think this will break alpine.
         if arch == "aarch64":
             return "aarch64-unknown-linux-gnu"
+        elif arch == "ppc64le":
+            return "powerpc64le-unknown-linux-gnu"
         elif arch == "s390x":
             return "s390x-ibm-linux-gnu"
         elif arch == "x86_64":

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -93,6 +93,16 @@ def rules_foreign_cc_dependencies(
 
     maybe(
         http_archive,
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz",
+        ],
+        sha256 = "29742e87275809b5e598dc2f04d86960cc7a55b3067d97221c9abbc9926bff0f",
+    )
+
+    maybe(
+        http_archive,
         name = "bazel_features",
         sha256 = "ba1282c1aa1d1fffdcf994ab32131d7c7551a9bc960fbf05f42d55a1b930cbfb",
         strip_prefix = "bazel_features-1.15.0",


### PR DESCRIPTION
ppc64le support was added to [bazel_platforms](https://github.com/bazelbuild/platforms/blob/dd28c190c563531c06ba3bd64eca1cc9ca3e667f/cpu/BUILD#L148) in 0.0.8, and rfcc has an [explicit dep on 0.0.11 now](https://github.com/bazel-contrib/rules_foreign_cc/blob/dfc81310cb56793242b521f10492bbb8ebf1f312/MODULE.bazel#L11) so it's probably safe to add it