### PR TITLE
bzlmod: prevent extension from registering repos

### DIFF
--- a/foreign_cc/extensions.bzl
+++ b/foreign_cc/extensions.bzl
@@ -21,6 +21,8 @@ def _init(module_ctx):
         register_default_tools = False,
         register_preinstalled_tools = False,
         register_built_pkgconfig_toolchain = True,
+        # These should be registered via bzlmod entries instead
+        register_repos = False,
     )
 
     versions = {

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -17,7 +17,8 @@ def rules_foreign_cc_dependencies(
         register_preinstalled_tools = True,
         register_built_tools = True,
         register_toolchains = True,
-        register_built_pkgconfig_toolchain = True):
+        register_built_pkgconfig_toolchain = True,
+        register_repos = True):
     """Call this function from the WORKSPACE file to initialize rules_foreign_cc \
     dependencies and let neccesary code generation happen \
     (Code generation is needed to support different variants of the C++ Starlark API.).
@@ -59,6 +60,10 @@ def rules_foreign_cc_dependencies(
             startup --windows_enable_symlinks -> This is required to enable symlinking to avoid long runfile paths
             build --action_env=MSYS=winsymlinks:nativestrict -> This is required to enable symlinking to avoid long runfile paths
             startup --output_user_root=C:/b  -> This is required to keep paths as short as possible
+
+        register_repos: If true, use repository rules to register the required
+            dependencies. (If you are using bzlmod, you probably do not want to set
+            this since it will create shadow copies of these repos)
     """
 
     register_framework_toolchains(register_toolchains = register_toolchains)
@@ -82,6 +87,9 @@ def rules_foreign_cc_dependencies(
 
     if register_preinstalled_tools:
         preinstalled_toolchains()
+
+    if not register_repos:
+        return
 
     maybe(
         http_archive,


### PR DESCRIPTION
repos registered via workspace mechanisms take priority over repos registered via bzlmod. This means that when the `tools` extension calls `rules_foreign_cc_dependencies`, all of the repos registered become private copies (called something like `@@_main~tools~bazel_skylib` reflecting that the `tools` extension registered a repo called `bazel_skylib`). This is often fine, but for anything that declares constraints (like the platforms repo) this causes rfcc to use (e.g.) `@@_main~tools~platforms//os:linux` instead of `@platforms//os:linux`, which causes a lot of things to break!

https://github.com/bazel-contrib/rules_foreign_cc/pull/1373#issuecomment-2696043851