### PR TITLE
feat: support make vars in postfix_script

### DIFF
--- a/examples/cmake_synthetic/BUILD.bazel
+++ b/examples/cmake_synthetic/BUILD.bazel
@@ -8,7 +8,7 @@ cmake(
     # Demonstrate non-alphanumeric name
     lib_name = "liba++",
     lib_source = "//cmake_synthetic/liba:a_srcs",
-    postfix_script = "cp -p $$INSTALLDIR$$/lib/liba.a $$INSTALLDIR$$/lib/liba++.a",
+    postfix_script = "cp -p $$INSTALLDIR/lib/liba.a $$INSTALLDIR/lib/liba++.a",
 )
 
 cmake(

--- a/examples/third_party/gn/BUILD.gn.bazel
+++ b/examples/third_party/gn/BUILD.gn.bazel
@@ -32,12 +32,12 @@ ninja(
     # gn has no install step, manually grab the artifacts
     postfix_script = select({
         ":windows": " && ".join([
-            "cp -a out/gn_lib.lib $$INSTALLDIR$$/lib",
-            "cp -a out/gn.exe $$INSTALLDIR$$/bin",
+            "cp -a out/gn_lib.lib $$INSTALLDIR/lib",
+            "cp -a out/gn.exe $$INSTALLDIR/bin",
         ]),
         "//conditions:default": " && ".join([
-            "cp -a out/gn_lib.a $$INSTALLDIR$$/lib",
-            "cp -a out/gn $$INSTALLDIR$$/bin",
+            "cp -a out/gn_lib.a $$INSTALLDIR/lib",
+            "cp -a out/gn $$INSTALLDIR/bin",
         ]),
     }),
 )

--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -168,7 +168,7 @@ def pkgconfig_tool(name, srcs, **kwargs):
             "@gettext_runtime",
         ],
         postfix_script = select({
-            "@platforms//os:windows": "cp release/x64/pkg-config.exe $$INSTALLDIR$$/bin",
+            "@platforms//os:windows": "cp release/x64/pkg-config.exe $$INSTALLDIR/bin",
             "//conditions:default": "",
         }),
         toolchain = str(Label("//toolchains:preinstalled_nmake_toolchain")),

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -44,13 +44,10 @@ def _configure_make(ctx):
             ctx.label,
         ))
 
-    copy_results = "##copy_dir_contents_to_dir## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ $$INSTALLDIR$$\n"
-
     attrs = create_attrs(
         ctx.attr,
         configure_name = "Configure",
         create_configure_script = _create_configure_script,
-        postfix_script = copy_results + "\n" + ctx.attr.postfix_script,
         tools_data = tools_data,
         make_path = make_data.path,
     )

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -98,6 +98,7 @@ def create_configure_script(
 
     script.extend(make_commands)
     script.append("##disable_tracing##")
+    script.append("##copy_dir_contents_to_dir## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ $$INSTALLDIR$$\n")
 
     return script
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -454,9 +454,10 @@ def cc_external_rule_impl(ctx, attrs):
     installdir = target_root + "/" + lib_name
     env_prelude = get_env_prelude(ctx, installdir, data_dependencies)
 
-    postfix_script = [attrs.postfix_script]
     if not attrs.postfix_script:
         postfix_script = []
+    else:
+        postfix_script = [expand_locations_and_make_variables(ctx, attrs.postfix_script, "postfix_script", data_dependencies)]
 
     script_lines = [
         "##echo## \"\"",


### PR DESCRIPTION
postfix_script did not support make vars which means we cannot use things like $(execpath :target) in it. This limited the functionality of the attribute.

Note, this is a breaking change as $$ wrapped variable declaration and single $ shell variable declaration will no longer work in postfix_script e.g. $$INSTALLDIR$$ and $INSTALLDIR. Need to used shell variable with an escaped $ like $$INSTALLDIR.