### PR TITLE
Add support for Emscripten

### DIFF
--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -23,6 +23,9 @@ _TARGET_OS_PARAMS = {
         "ANDROID": "YES",
         "CMAKE_SYSTEM_NAME": "Linux",
     },
+    "emscripten": {
+        "CMAKE_SYSTEM_NAME": "Emscripten",
+    },
     "linux": {
         "CMAKE_SYSTEM_NAME": "Linux",
     },
@@ -37,6 +40,14 @@ _TARGET_ARCH_PARAMS = {
     },
     "s390x": {
         "CMAKE_SYSTEM_PROCESSOR": "s390x",
+    },
+    # Emscripten configures CMAKE_SYSTEM_PROCESSOR as follows for compatibility with libraries such as OpenCV
+    # https://github.com/emscripten-core/emscripten/blob/79ee3d1/cmake/Modules/Platform/Emscripten.cmake#L23-L30
+    "wasm32": {
+        "CMAKE_SYSTEM_PROCESSOR": "x86",
+    },
+    "wasm64": {
+        "CMAKE_SYSTEM_PROCESSOR": "x86_64",
     },
     "x86_64": {
         "CMAKE_SYSTEM_PROCESSOR": "x86_64",

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -4,11 +4,14 @@ SUPPORTED_CPU = [
     "aarch64",
     "ppc64le",
     "s390x",
+    "wasm32",
+    "wasm64",
     "x86_64",
 ]
 
 SUPPORTED_OS = [
     "android",
+    "emscripten",
     "freebsd",
     "ios",
     "linux",
@@ -17,6 +20,7 @@ SUPPORTED_OS = [
     "openbsd",
     "qnx",
     "tvos",
+    "wasi",
     "watchos",
     "windows",
 ]
@@ -213,5 +217,11 @@ def triplet_name(os, arch):
             return "aarch64-apple-darwin21"
         elif arch == "x86_64":
             return "x86_64-apple-darwin21"
+
+    elif os == "emscripten":
+        if arch == "wasm32":
+            return "wasm32-unknown-emscripten"
+        elif arch == "wasm64":
+            return "wasm64-unknown-emscripten"
 
     return "unknown"


### PR DESCRIPTION
This PR adds the definitions for the CPUs and OSes used in WebAssembly, specifically, for Emscripten. Just testing in CI for now.