### PR TITLE
Absolutize paths beginning with `bazel-out/`

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -353,9 +353,10 @@ def _add_if_needed(arr, add_arr):
 def absolutize_path_in_str(workspace_name, root_str, text, force = False):
     """Replaces relative paths in [the middle of] 'text', prepending them with 'root_str'. If there is nothing to replace, returns the 'text'.
 
-    We only will replace relative paths starting with either 'external/' or '<top-package-name>/',
-    because we only want to point with absolute paths to external repositories or inside our
-    current workspace. (And also to limit the possibility of error with such not exact replacing.)
+    We only will replace relative paths starting with either 'external/', 'bazel-out/', or
+    '<top-package-name>/', because we only want to point with absolute paths to external
+    repositories or inside our current workspace. (And also to limit the possibility of error with
+    such not exact replacing.)
 
     Args:
         workspace_name: workspace name
@@ -368,7 +369,9 @@ def absolutize_path_in_str(workspace_name, root_str, text, force = False):
     """
     new_text = _prefix(text, "external/", root_str)
     if new_text == text:
-        new_text = _prefix(text, workspace_name + "/", root_str)
+        new_text = _prefix(text, "bazel-out/", root_str)
+        if new_text == text:
+            new_text = _prefix(text, workspace_name + "/", root_str)
 
     # Check to see if the text is already absolute on a unix and windows system
     is_already_absolute = text.startswith("/") or \


### PR DESCRIPTION
We currently only absolutize relative paths starting with either `external/` or `<top-package-name>/`. This commit changes that to include paths that begin with `bazel-out/` to allow rules_foreign_cc to work with Bazel-generated sysroots.