### PR TITLE
fix: allow rules to consume tools env data

### DIFF
--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -112,7 +112,7 @@ def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic, additional_tools 
 
     root = detect_root(ctx.attr.srcs)
     lib_name = ctx.attr.name
-    env_prelude = get_env_prelude(ctx, out_dir.path, [])
+    env_prelude = get_env_prelude(ctx, out_dir.path, [], {})
 
     cc_toolchain = find_cpp_toolchain(ctx)
 

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -156,14 +156,18 @@ load(
 load(
     "//toolchains/native_tools:tool_access.bzl",
     "get_cmake_data",
+    "get_m4_data",
     "get_make_data",
     "get_ninja_data",
+    "get_pkgconfig_data",
 )
 
 def _cmake_impl(ctx):
     cmake_data = get_cmake_data(ctx)
+    pkgconfig_data = get_pkgconfig_data(ctx)
+    m4_data = get_m4_data(ctx)
 
-    tools_data = [cmake_data]
+    tools_data = [cmake_data, pkgconfig_data, m4_data]
 
     env = dict(ctx.attr.env)
 

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -21,13 +21,29 @@ load(
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
-load("//toolchains/native_tools:tool_access.bzl", "get_make_data", "get_pkgconfig_data")
+load(
+    "//toolchains/native_tools:tool_access.bzl",
+    "get_autoconf_data",
+    "get_automake_data",
+    "get_m4_data",
+    "get_make_data",
+    "get_pkgconfig_data",
+)
 
 def _configure_make(ctx):
     make_data = get_make_data(ctx)
     pkg_config_data = get_pkgconfig_data(ctx)
+    autoconf_data = get_autoconf_data(ctx)
+    automake_data = get_automake_data(ctx)
+    m4_data = get_m4_data(ctx)
 
-    tools_data = [make_data, pkg_config_data]
+    tools_data = [
+        make_data,
+        pkg_config_data,
+        autoconf_data,
+        automake_data,
+        m4_data,
+    ]
 
     if ctx.attr.autogen and not ctx.attr.configure_in_place:
         fail("`autogen` requires `configure_in_place = True`. Please update {}".format(

--- a/toolchains/native_tools/tool_access.bzl
+++ b/toolchains/native_tools/tool_access.bzl
@@ -47,13 +47,22 @@ def _access_and_expect_label_copied(toolchain_type_, ctx):
         # This could be made more efficient by changing the
         # toolchain to provide the executable as a target
         cmd_file = tool_data
+        tool_env = dict(tool_data.env)
+
         for f in tool_data.target.files.to_list():
             if f.path.endswith("/" + tool_data.path):
                 cmd_file = f
                 break
+
+        # Environment vars for tools such as MAKE and CMAKE needs to be absolute
+        # as they are used from build_tmpdir and not bazel's exec/sandbox root
+        for k, v in tool_env.items():
+            if v.endswith(tool_data.path):
+                tool_env[k] = "$EXT_BUILD_ROOT/{}".format(cmd_file.path)
+
         return struct(
             target = tool_data.target,
-            env = tool_data.env,
+            env = tool_env,
             # as the tool will be copied into tools directory
             path = "$EXT_BUILD_ROOT/{}".format(cmd_file.path),
         )


### PR DESCRIPTION
This fixes a bug where cmake and configure_make rules does not get env data from toolchains built by native_tool_toolchain rule.