### PR TITLE
fix: broken msvc builds

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -748,7 +748,9 @@ def _correct_path_variable(toolchain, env):
                     # INCLUDE) needs windows path (for passing as arguments to compiler).
                     prefix = "${EXT_BUILD_ROOT/$(printf '\072')/}/"
                 else:
-                    prefix = "\"$EXT_BUILD_ROOT\"/"
+                    # Don't add extra quotes for shellcheck. The place where it gets used
+                    # should be quoted instead.
+                    prefix = "$EXT_BUILD_ROOT/"
 
                 # external/path becomes $EXT_BUILD_ROOT/external/path
                 path_paths = [prefix + path if path and path[1] != ":" else path for path in value.split(";")]


### PR DESCRIPTION
Using "\"$EXT_BUILD_ROOT\"/" with the extra \"s is unnecessary. The extra quote should be applied to string where this is used. Otherwise this causes odd path problems for msvc.

Notably, in get_env_prelude, this causes LIB and INCLUDE env vars to expand to something like:
LIB="\\\\\"$EXT_BUILD_ROOT\\\\\"/external/toolchain..." This is not recognized as a valid path when running through msys2 on windows and causes all kinds of pain.