### PR TITLE
Fix target name for meson_with_requirements

### DIFF
--- a/foreign_cc/private/transitions.bzl
+++ b/foreign_cc/private/transitions.bzl
@@ -52,22 +52,22 @@ def foreign_cc_rule_variant(name, rule, toolchain, **kwargs):
         **kwargs: Remaining keyword arguments
     """
 
-    foreign_cc_rule_target_name = name + "_"
+    extra_toolchains_target_name = name + "_"
 
     tags = kwargs.pop("tags", [])
     visibility = kwargs.pop("visibility", [])
 
     rule(
-        name = foreign_cc_rule_target_name,
+        name = name,
         tags = tags + ["manual"],
         visibility = visibility,
         **kwargs
     )
 
     extra_toolchains_transitioned_foreign_cc_target(
-        name = name,
+        name = extra_toolchains_target_name,
         extra_toolchain = toolchain,
-        target = foreign_cc_rule_target_name,
+        target = name,
         tags = tags,
         visibility = visibility,
     )


### PR DESCRIPTION
`meson_with_requirements` has a small quirk where the resulting rule name ends up with an '_' postfixed to the end. This is unexpected and a bit annoying when the meson project is a dependency of another rule since you have to remember to add the _ in any include paths etc.