### PR TITLE
fix: remove system dependency on python3

### DIFF
--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -261,7 +261,7 @@ def replace_symlink(file):
     # as `readlink` is.
     return """\
 if [[ -L "{file}" ]]; then
-  target="$(python3 -c "import os; print(os.path.realpath('{file}'))")"
+  target="$(realpath '{file}')"
   rm "{file}" && cp -a "${{target}}" "{file}"
 fi
 """.format(file = file)


### PR DESCRIPTION
The replace_symlink implementation on darwin called out to the darwin system trampoline python3 version; this breaks with toolchains that have a hermetic SDKROOT (because the trampolines don't know how to read a relative value, and bazel registers it as an absolute path violation if it's absolute).

realpath appears to have been added to the osx base system in Ventura (13), and according to https://endoflife.date/macos Monterey (12) went end of life back in September 2024.