### PR TITLE
Mark extension as reproducible

### DIFF
--- a/foreign_cc/extensions.bzl
+++ b/foreign_cc/extensions.bzl
@@ -1,5 +1,6 @@
 """Entry point for extensions used by bzlmod."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load("//toolchains:prebuilt_toolchains.bzl", "prebuilt_toolchains")
 
@@ -43,6 +44,11 @@ def _init(module_ctx):
         ninja_version = versions["ninja"],
         register_toolchains = False,
     )
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
+    else:
+        return None
 
 tools = module_extension(
     implementation = _init,


### PR DESCRIPTION
This avoids a lot of unnecessary lockfile noise.