### PR TITLE
Absolutize exec-root-relative cc_toolchain env values for all toolchains

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -830,6 +830,18 @@ def _correct_path_variable(toolchain, env):
                 path_paths = [prefix + path if path and path[1] != ":" else path for path in value.split(";")]
                 corrected_env[key] = ";".join(path_paths)
         env = corrected_env
+    else:
+        # Anchor exec-root-relative paths (external/, bazel-out/) in env values to
+        # $EXT_BUILD_ROOT, since foreign builds run outside the exec root.
+        corrected_env = dict()
+        for key, value in env.items():
+            if key != "PATH":
+                value = ":".join([
+                    "$EXT_BUILD_ROOT/" + path if path.startswith("external/") or path.startswith("bazel-out/") else path
+                    for path in value.split(":")
+                ])
+            corrected_env[key] = value
+        env = corrected_env
 
     value = env.get("PATH")
     if value == None:


### PR DESCRIPTION
foreign_cc forwards the resolved cc_toolchain's action environment into the generated build script verbatim, but runs the foreign build system with a working directory outside the exec root. Toolchains can carry tool paths in that environment (rules_cc's cc_tool.env renders file paths exec-root-relative, which is correct for regular Bazel actions), and those paths silently stop resolving under foreign_cc. Concretely, the BCR llvm module's linker wrapper locates the real compiler through an LLVM_CLANGXX env var, and cmake's first C++ ABI probe fails with:

    link-wrapper: failed to execute external/llvm++.../bin/clang++:
    No such file or directory

_correct_path_variable already solves exactly this for msvc-cl by prefixing the known MSVC path variables with the literal "$EXT_BUILD_ROOT/", expanded at script runtime. Extend the same mechanism to every toolchain: prefix any env value that is wholly an exec-root-relative path (starts with external/ or bazel-out/), leaving PATH to its dedicated handling below. The prefix is a literal at analysis time, so action keys and remote-cache behavior are unchanged.

(Claude-authored, human-reviewed)